### PR TITLE
Fix left arrow for Western Objectives

### DIFF
--- a/src/components/match/Objectives.tsx
+++ b/src/components/match/Objectives.tsx
@@ -5,6 +5,7 @@ import { GiConvergenceTarget } from 'react-icons/gi';
 import {
   RiArrowDownFill,
   RiArrowLeftDownFill,
+  RiArrowLeftFill,
   RiArrowLeftUpFill,
   RiArrowRightDownFill,
   RiArrowRightFill,
@@ -175,7 +176,7 @@ const DirectionIconsMap: Record<Direction, IconType> = {
   C: GiConvergenceTarget,
   N: RiArrowUpFill,
   E: RiArrowRightFill,
-  W: RiArrowRightFill,
+  W: RiArrowLeftFill,
   S: RiArrowDownFill,
   NW: RiArrowLeftUpFill,
   NE: RiArrowRightUpFill,


### PR DESCRIPTION
Currently Objectives that are located on the Western part of the map are wrongly using the Right Arrow, same as Eastern objectives, instead of the correct Left Arrow.

Affected objectives:

- Blistering Undercroft
- Dreadfall Bay
- Ascension Bay
- Speldan Clearcut
- Danelon Passage
- Rogue's Quarry

This is my first Pull Request, with no knowledge of TypeScript. If anything is wrong, let me know.